### PR TITLE
feat: HabitFormコンポーネントのE2Eテストを追加

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -24,7 +24,8 @@
       "Bash(rg:*)",
       "Bash(rm:*)",
       "mcp__context7__resolve-library-id",
-      "mcp__context7__get-library-docs"
+      "mcp__context7__get-library-docs",
+      "Bash(gh issue view:*)"
     ],
     "defaultMode": "acceptEdits",
     "additionalDirectories": [

--- a/e2e/auth-setup.ts
+++ b/e2e/auth-setup.ts
@@ -1,0 +1,34 @@
+import path from 'path';
+
+import { chromium, FullConfig } from '@playwright/test';
+
+const STORAGE_STATE_PATH = path.join(__dirname, '.auth/user.json');
+
+async function globalSetup(config: FullConfig) {
+  const { baseURL } = config.projects[0].use;
+  const browser = await chromium.launch();
+  const context = await browser.newContext();
+  const page = await context.newPage();
+
+  try {
+    await page.goto(`${baseURL}/auth/signin`);
+    await page.waitForLoadState('networkidle');
+
+    const emailInput = page.locator('input[type="email"]');
+    const passwordInput = page.locator('input[type="password"]');
+    const submitButton = page.locator('button[type="submit"]');
+
+    await emailInput.fill('test@example.com');
+    await passwordInput.fill('password123');
+    await submitButton.click();
+
+    await page.waitForURL(`${baseURL}/`, { timeout: 30000 });
+
+    await context.storageState({ path: STORAGE_STATE_PATH });
+  } finally {
+    await context.close();
+    await browser.close();
+  }
+}
+
+export default globalSetup;

--- a/e2e/habit-form.spec.ts
+++ b/e2e/habit-form.spec.ts
@@ -1,0 +1,232 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Habit Form', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+    await page.waitForLoadState('networkidle');
+  });
+
+  test('should open habit form dialog when clicking new habit button', async ({ page }) => {
+    const newHabitButton = page.locator('[data-testid="add-habit-button"]');
+    await newHabitButton.click();
+
+    const dialog = page.locator('[data-testid="habit-form-dialog"]');
+    await expect(dialog).toBeVisible();
+
+    await expect(page.locator('[data-testid="habit-form-title"]')).toHaveText('新しい習慣を追加');
+    await expect(page.locator('[data-testid="habit-form-description"]')).toContainText('習慣の名前、目標回数、頻度を入力してください');
+  });
+
+  test('should display all form fields', async ({ page }) => {
+    const newHabitButton = page.locator('[data-testid="add-habit-button"]');
+    await newHabitButton.click();
+
+    await expect(page.locator('[data-testid="habit-name-label"]')).toContainText('習慣名');
+    await expect(page.locator('[data-testid="habit-name-input"]')).toBeVisible();
+
+    await expect(page.locator('[data-testid="habit-target-label"]')).toContainText('目標回数');
+    await expect(page.locator('[data-testid="habit-target-input"]')).toBeVisible();
+
+    await expect(page.locator('[data-testid="habit-frequency-label"]')).toContainText('頻度');
+    await expect(page.locator('[data-testid="habit-frequency-select"]')).toBeVisible();
+
+    await expect(page.locator('[data-testid="habit-form-cancel-button"]')).toContainText('キャンセル');
+    await expect(page.locator('[data-testid="habit-form-submit-button"]')).toContainText('保存');
+  });
+
+  test('should show validation errors when submitting empty form', async ({ page }) => {
+    const newHabitButton = page.locator('[data-testid="add-habit-button"]');
+    await newHabitButton.click();
+
+    const submitButton = page.locator('[data-testid="habit-form-submit-button"]');
+    await submitButton.click();
+
+    await expect(page.locator('[data-testid="habit-name-error"]')).toContainText('習慣名を入力してください');
+    await expect(page.locator('[data-testid="habit-target-error"]')).toContainText('目標回数を入力してください');
+    await expect(page.locator('[data-testid="habit-frequency-error"]')).toContainText('頻度タイプを選択してください');
+  });
+
+  test('should show validation error for invalid target count', async ({ page }) => {
+    const newHabitButton = page.locator('[data-testid="add-habit-button"]');
+    await newHabitButton.click();
+
+    await page.fill('[data-testid="habit-name-input"]', 'テスト習慣');
+    await page.fill('[data-testid="habit-target-input"]', '0');
+
+    const submitButton = page.locator('[data-testid="habit-form-submit-button"]');
+    await submitButton.click();
+
+    await expect(page.locator('[data-testid="habit-target-error"]')).toContainText('目標回数は1以上の数値を入力してください');
+  });
+
+  test('should create new habit successfully with weekly frequency', async ({ page }) => {
+    const newHabitButton = page.locator('[data-testid="add-habit-button"]');
+    await newHabitButton.click();
+
+    await page.fill('[data-testid="habit-name-input"]', 'E2Eテスト習慣（週間）');
+    await page.fill('[data-testid="habit-target-input"]', '5');
+
+    await page.click('[data-testid="habit-frequency-select"]');
+    await page.click('[data-testid="habit-frequency-weekly"]');
+
+    const submitButton = page.locator('[data-testid="habit-form-submit-button"]');
+    await submitButton.click();
+
+    await page.waitForLoadState('networkidle');
+
+    const habitCards = page.locator('[data-testid="habit-card"]');
+    await expect(habitCards).not.toHaveCount(0);
+  });
+
+  test('should create new habit successfully with monthly frequency', async ({ page }) => {
+    const newHabitButton = page.locator('[data-testid="add-habit-button"]');
+    await newHabitButton.click();
+
+    await page.fill('[data-testid="habit-name-input"]', 'E2Eテスト習慣（月間）');
+    await page.fill('[data-testid="habit-target-input"]', '10');
+
+    await page.click('[data-testid="habit-frequency-select"]');
+    await page.click('[data-testid="habit-frequency-monthly"]');
+
+    const submitButton = page.locator('[data-testid="habit-form-submit-button"]');
+    await submitButton.click();
+
+    await page.waitForLoadState('networkidle');
+
+    const habitCards = page.locator('[data-testid="habit-card"]');
+    await expect(habitCards).not.toHaveCount(0);
+  });
+
+  test('should close dialog when clicking cancel button', async ({ page }) => {
+    const newHabitButton = page.locator('[data-testid="add-habit-button"]');
+    await newHabitButton.click();
+
+    await page.fill('[data-testid="habit-name-input"]', 'キャンセルテスト');
+    await page.fill('[data-testid="habit-target-input"]', '3');
+
+    const cancelButton = page.locator('[data-testid="habit-form-cancel-button"]');
+    await cancelButton.click();
+
+    const dialog = page.locator('[data-testid="habit-form-dialog"]');
+    await expect(dialog).not.toBeVisible();
+  });
+
+  test('should clear form data after canceling', async ({ page }) => {
+    const newHabitButton = page.locator('[data-testid="add-habit-button"]');
+    await newHabitButton.click();
+
+    await page.fill('[data-testid="habit-name-input"]', 'データクリアテスト');
+    await page.fill('[data-testid="habit-target-input"]', '7');
+    await page.click('[data-testid="habit-frequency-select"]');
+    await page.click('[data-testid="habit-frequency-weekly"]');
+
+    const cancelButton = page.locator('[data-testid="habit-form-cancel-button"]');
+    await cancelButton.click();
+
+    await newHabitButton.click();
+
+    await expect(page.locator('[data-testid="habit-name-input"]')).toHaveValue('');
+    await expect(page.locator('[data-testid="habit-target-input"]')).toHaveValue('');
+  });
+
+  test('should disable form fields while submitting', async ({ page }) => {
+    const newHabitButton = page.locator('[data-testid="add-habit-button"]');
+    await newHabitButton.click();
+
+    await page.fill('[data-testid="habit-name-input"]', 'ローディングテスト');
+    await page.fill('[data-testid="habit-target-input"]', '3');
+    await page.click('[data-testid="habit-frequency-select"]');
+    await page.click('[data-testid="habit-frequency-weekly"]');
+
+    await page.route('**/api/habits', async (route) => {
+      await page.waitForTimeout(1000);
+      await route.continue();
+    });
+
+    const submitButton = page.locator('[data-testid="habit-form-submit-button"]');
+    await submitButton.click();
+
+    await expect(page.locator('[data-testid="habit-name-input"]')).toBeDisabled();
+    await expect(page.locator('[data-testid="habit-target-input"]')).toBeDisabled();
+    await expect(submitButton).toBeDisabled();
+  });
+
+  test('should show loading state on submit button', async ({ page }) => {
+    const newHabitButton = page.locator('[data-testid="add-habit-button"]');
+    await newHabitButton.click();
+
+    await page.fill('[data-testid="habit-name-input"]', 'ボタンローディングテスト');
+    await page.fill('[data-testid="habit-target-input"]', '4');
+    await page.click('[data-testid="habit-frequency-select"]');
+    await page.click('[data-testid="habit-frequency-monthly"]');
+
+    await page.route('**/api/habits', async (route) => {
+      await page.waitForTimeout(500);
+      await route.continue();
+    });
+
+    const submitButton = page.locator('[data-testid="habit-form-submit-button"]');
+    await submitButton.click();
+
+    await expect(submitButton).toContainText('保存中...');
+  });
+
+  test('should be responsive on mobile', async ({ page }) => {
+    await page.setViewportSize({ width: 375, height: 667 });
+
+    const newHabitButton = page.locator('[data-testid="add-habit-button"]');
+    await newHabitButton.click();
+
+    const dialog = page.locator('[data-testid="habit-form-dialog"]');
+    await expect(dialog).toBeVisible();
+
+    await expect(page.locator('[data-testid="habit-name-input"]')).toBeVisible();
+    await expect(page.locator('[data-testid="habit-target-input"]')).toBeVisible();
+    await expect(page.locator('[data-testid="habit-frequency-select"]')).toBeVisible();
+    await expect(page.locator('[data-testid="habit-form-submit-button"]')).toBeVisible();
+    await expect(page.locator('[data-testid="habit-form-cancel-button"]')).toBeVisible();
+  });
+
+  test('should be responsive on tablet', async ({ page }) => {
+    await page.setViewportSize({ width: 768, height: 1024 });
+
+    const newHabitButton = page.locator('[data-testid="add-habit-button"]');
+    await newHabitButton.click();
+
+    const dialog = page.locator('[data-testid="habit-form-dialog"]');
+    await expect(dialog).toBeVisible();
+
+    await expect(page.locator('[data-testid="habit-name-input"]')).toBeVisible();
+    await expect(page.locator('[data-testid="habit-target-input"]')).toBeVisible();
+    await expect(page.locator('[data-testid="habit-frequency-select"]')).toBeVisible();
+  });
+
+  test('should handle input with Japanese characters', async ({ page }) => {
+    const newHabitButton = page.locator('[data-testid="add-habit-button"]');
+    await newHabitButton.click();
+
+    const habitName = '朝のランニング🏃‍♂️';
+    await page.fill('[data-testid="habit-name-input"]', habitName);
+
+    const nameInput = page.locator('[data-testid="habit-name-input"]');
+    await expect(nameInput).toHaveValue(habitName);
+  });
+
+  test('should trim whitespace from habit name', async ({ page }) => {
+    const newHabitButton = page.locator('[data-testid="add-habit-button"]');
+    await newHabitButton.click();
+
+    await page.fill('[data-testid="habit-name-input"]', '  スペーステスト  ');
+    await page.fill('[data-testid="habit-target-input"]', '5');
+    await page.click('[data-testid="habit-frequency-select"]');
+    await page.click('[data-testid="habit-frequency-weekly"]');
+
+    const submitButton = page.locator('[data-testid="habit-form-submit-button"]');
+    await submitButton.click();
+
+    await page.waitForLoadState('networkidle');
+
+    const habitCards = page.locator('[data-testid="habit-card"]');
+    await expect(habitCards).not.toHaveCount(0);
+  });
+});

--- a/middleware.ts
+++ b/middleware.ts
@@ -17,6 +17,11 @@ export async function middleware(request: NextRequest) {
     },
   });
 
+  // E2Eテストモード: 認証をスキップ
+  if (process.env.E2E_TEST_MODE === 'true') {
+    return response;
+  }
+
   const supabase = createServerClient(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
     process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -7,7 +7,6 @@ export default defineConfig({
   retries: process.env.CI ? 2 : 0,
   workers: process.env.CI ? 1 : undefined,
   reporter: 'html',
-  globalSetup: require.resolve('./e2e/global-setup'),
   use: {
     baseURL: 'http://localhost:3000',
     trace: 'on-first-retry',
@@ -45,5 +44,8 @@ export default defineConfig({
     url: 'http://localhost:3000',
     reuseExistingServer: !process.env.CI,
     timeout: 120 * 1000,
+    env: {
+      E2E_TEST_MODE: 'true',
+    },
   },
 });

--- a/src/app/DashboardPage.tsx
+++ b/src/app/DashboardPage.tsx
@@ -1,7 +1,9 @@
 'use client';
 
 import { Plus } from 'lucide-react';
+import * as React from 'react';
 
+import { HabitForm } from '@/components/feature/HabitForm';
 import { Button } from '@/components/ui/Button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/Card';
 import { Progress } from '@/components/ui/Progress';
@@ -16,6 +18,7 @@ export default function DashboardPage({
   habits,
   habitLogs,
 }: DashboardPageProps) {
+  const [isFormOpen, setIsFormOpen] = React.useState(false);
 
   // 今週/今月の進捗を計算する関数
   const getProgress = (habit: Habit) => {
@@ -71,11 +74,13 @@ export default function DashboardPage({
     <div className="container mx-auto p-6">
       <div className="mb-8 flex items-center justify-between">
         <h1 className="text-3xl font-bold">習慣記録</h1>
-        <Button>
+        <Button onClick={() => setIsFormOpen(true)} data-testid="add-habit-button">
           <Plus className="mr-2 h-4 w-4" />
           新しい習慣
         </Button>
       </div>
+
+      <HabitForm open={isFormOpen} onOpenChange={setIsFormOpen} />
 
       <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
         {habits.map((habit) => {
@@ -125,7 +130,7 @@ export default function DashboardPage({
       {habits.length === 0 && (
         <div className="py-12 text-center">
           <CardDescription className="mb-4">まだ習慣が登録されていません</CardDescription>
-          <Button>
+          <Button onClick={() => setIsFormOpen(true)} data-testid="add-first-habit-button">
             <Plus className="mr-2 h-4 w-4" />
             最初の習慣を追加
           </Button>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,11 +1,10 @@
+import DashboardPage from '@/app/DashboardPage';
 import { serverTypedGet } from '@/lib/api-client/server-fetch';
 import { requireAuth } from '@/lib/auth/server';
 import {
   HabitLogsGetResponseSchema,
   HabitsGetResponseSchema,
 } from '@/lib/schemas/api-response';
-
-import DashboardPage from './DashboardPage';
 
 export default async function HomePage() {
   await requireAuth('/');

--- a/src/components/feature/HabitForm/HabitForm.stories.tsx
+++ b/src/components/feature/HabitForm/HabitForm.stories.tsx
@@ -1,0 +1,44 @@
+import type { Meta, StoryObj } from '@storybook/nextjs';
+import { useState } from 'react';
+
+import { Button } from '@/components/ui/Button';
+
+import { HabitForm } from './HabitForm';
+
+const meta = {
+  title: 'Feature/HabitForm',
+  component: HabitForm,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+} satisfies Meta<typeof HabitForm>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const DefaultStory = () => {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <div>
+      <Button onClick={() => setOpen(true)}>習慣を追加</Button>
+      <HabitForm open={open} onOpenChange={setOpen} />
+    </div>
+  );
+};
+
+export const Default: Story = {
+  args: {
+    open: false,
+    onOpenChange: () => {},
+  },
+  render: DefaultStory,
+};
+
+export const Open: Story = {
+  args: {
+    open: true,
+    onOpenChange: () => {},
+  },
+};

--- a/src/components/feature/HabitForm/HabitForm.tsx
+++ b/src/components/feature/HabitForm/HabitForm.tsx
@@ -1,0 +1,213 @@
+'use client';
+
+import * as React from 'react';
+
+import { Button } from '@/components/ui/Button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/Dialog';
+import { Input } from '@/components/ui/Input';
+import { Label } from '@/components/ui/Label';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/Select';
+
+interface HabitFormProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+export function HabitForm({ open, onOpenChange }: HabitFormProps) {
+  const [name, setName] = React.useState('');
+  const [targetCount, setTargetCount] = React.useState('');
+  const [frequencyType, setFrequencyType] = React.useState<'weekly' | 'monthly' | ''>('');
+  const [errors, setErrors] = React.useState<{
+    name?: string;
+    targetCount?: string;
+    frequencyType?: string;
+  }>({});
+  const [isLoading, setIsLoading] = React.useState(false);
+
+  const validateForm = () => {
+    const newErrors: typeof errors = {};
+
+    if (!name.trim()) {
+      newErrors.name = '習慣名を入力してください';
+    }
+
+    if (!targetCount.trim()) {
+      newErrors.targetCount = '目標回数を入力してください';
+    } else {
+      const count = parseInt(targetCount, 10);
+      if (isNaN(count) || count < 1) {
+        newErrors.targetCount = '目標回数は1以上の数値を入力してください';
+      }
+    }
+
+    if (!frequencyType) {
+      newErrors.frequencyType = '頻度タイプを選択してください';
+    }
+
+    setErrors(newErrors);
+    return Object.keys(newErrors).length === 0;
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+
+    if (!validateForm()) {
+      return;
+    }
+
+    setIsLoading(true);
+
+    try {
+      const response = await fetch('/api/habits', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          name: name.trim(),
+          targetCount: parseInt(targetCount, 10),
+          frequencyType,
+        }),
+      });
+
+      if (!response.ok) {
+        throw new Error('Failed to create habit');
+      }
+
+      setName('');
+      setTargetCount('');
+      setFrequencyType('');
+      setErrors({});
+      onOpenChange(false);
+      window.location.reload();
+    } catch (error) {
+      console.error('Failed to create habit:', error);
+      setErrors({ name: '習慣の作成に失敗しました。もう一度お試しください。' });
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const handleCancel = () => {
+    setName('');
+    setTargetCount('');
+    setFrequencyType('');
+    setErrors({});
+    onOpenChange(false);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent data-testid="habit-form-dialog">
+        <DialogHeader>
+          <DialogTitle data-testid="habit-form-title">新しい習慣を追加</DialogTitle>
+          <DialogDescription data-testid="habit-form-description">
+            習慣の名前、目標回数、頻度を入力してください
+          </DialogDescription>
+        </DialogHeader>
+
+        <form onSubmit={handleSubmit}>
+          <div className="grid gap-4 py-4">
+            <div className="grid gap-2">
+              <Label htmlFor="name" data-testid="habit-name-label">
+                習慣名
+              </Label>
+              <Input
+                id="name"
+                data-testid="habit-name-input"
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                placeholder="例: ランニング"
+                disabled={isLoading}
+              />
+              {errors.name && (
+                <p className="text-sm text-black dark:text-white" data-testid="habit-name-error">
+                  {errors.name}
+                </p>
+              )}
+            </div>
+
+            <div className="grid gap-2">
+              <Label htmlFor="targetCount" data-testid="habit-target-label">
+                目標回数
+              </Label>
+              <Input
+                id="targetCount"
+                data-testid="habit-target-input"
+                type="number"
+                min="1"
+                value={targetCount}
+                onChange={(e) => setTargetCount(e.target.value)}
+                placeholder="例: 3"
+                disabled={isLoading}
+              />
+              {errors.targetCount && (
+                <p className="text-sm text-black dark:text-white" data-testid="habit-target-error">
+                  {errors.targetCount}
+                </p>
+              )}
+            </div>
+
+            <div className="grid gap-2">
+              <Label htmlFor="frequencyType" data-testid="habit-frequency-label">
+                頻度
+              </Label>
+              <Select
+                value={frequencyType}
+                onValueChange={(value) => setFrequencyType(value as 'weekly' | 'monthly')}
+                disabled={isLoading}
+              >
+                <SelectTrigger id="frequencyType" data-testid="habit-frequency-select">
+                  <SelectValue placeholder="頻度を選択" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="weekly" data-testid="habit-frequency-weekly">
+                    週間
+                  </SelectItem>
+                  <SelectItem value="monthly" data-testid="habit-frequency-monthly">
+                    月間
+                  </SelectItem>
+                </SelectContent>
+              </Select>
+              {errors.frequencyType && (
+                <p className="text-sm text-black dark:text-white" data-testid="habit-frequency-error">
+                  {errors.frequencyType}
+                </p>
+              )}
+            </div>
+          </div>
+
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={handleCancel}
+              disabled={isLoading}
+              data-testid="habit-form-cancel-button"
+            >
+              キャンセル
+            </Button>
+            <Button
+              type="submit"
+              disabled={isLoading}
+              data-testid="habit-form-submit-button"
+            >
+              {isLoading ? '保存中...' : '保存'}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/feature/HabitForm/index.ts
+++ b/src/components/feature/HabitForm/index.ts
@@ -1,0 +1,1 @@
+export { HabitForm } from './HabitForm';

--- a/src/components/ui/Dialog/Dialog.tsx
+++ b/src/components/ui/Dialog/Dialog.tsx
@@ -1,0 +1,122 @@
+'use client';
+
+import * as DialogPrimitive from '@radix-ui/react-dialog';
+import { X } from 'lucide-react';
+import * as React from 'react';
+
+import { cn } from '@/lib/ui-utils';
+
+const Dialog = DialogPrimitive.Root;
+
+const DialogTrigger = DialogPrimitive.Trigger;
+
+const DialogPortal = DialogPrimitive.Portal;
+
+const DialogClose = DialogPrimitive.Close;
+
+const DialogOverlay = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Overlay
+    ref={ref}
+    className={cn(
+      'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/80',
+      className
+    )}
+    {...props}
+  />
+));
+DialogOverlay.displayName = DialogPrimitive.Overlay.displayName;
+
+const DialogContent = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
+>(({ className, children, ...props }, ref) => (
+  <DialogPortal>
+    <DialogOverlay />
+    <DialogPrimitive.Content
+      ref={ref}
+      className={cn(
+        'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] fixed top-[50%] left-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border-2 border-black bg-white p-6 shadow-lg duration-200 sm:rounded-lg dark:border-white dark:bg-black',
+        className
+      )}
+      {...props}
+    >
+      {children}
+      <DialogPrimitive.Close className="absolute top-4 right-4 rounded-sm opacity-70 ring-offset-white transition-opacity hover:opacity-100 focus:ring-2 focus:ring-black focus:ring-offset-2 focus:outline-none disabled:pointer-events-none data-[state=open]:bg-gray dark:ring-offset-black dark:focus:ring-white dark:data-[state=open]:bg-gray">
+        <X className="h-4 w-4" />
+        <span className="sr-only">Close</span>
+      </DialogPrimitive.Close>
+    </DialogPrimitive.Content>
+  </DialogPortal>
+));
+DialogContent.displayName = DialogPrimitive.Content.displayName;
+
+const DialogHeader = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn(
+      'flex flex-col space-y-1.5 text-center sm:text-left',
+      className
+    )}
+    {...props}
+  />
+);
+DialogHeader.displayName = 'DialogHeader';
+
+const DialogFooter = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn(
+      'flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2',
+      className
+    )}
+    {...props}
+  />
+);
+DialogFooter.displayName = 'DialogFooter';
+
+const DialogTitle = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Title>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Title>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Title
+    ref={ref}
+    className={cn(
+      'text-lg leading-none font-semibold tracking-tight',
+      className
+    )}
+    {...props}
+  />
+));
+DialogTitle.displayName = DialogPrimitive.Title.displayName;
+
+const DialogDescription = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Description>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Description>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Description
+    ref={ref}
+    className={cn('text-sm text-black/70 dark:text-white/70', className)}
+    {...props}
+  />
+));
+DialogDescription.displayName = DialogPrimitive.Description.displayName;
+
+export {
+  Dialog,
+  DialogPortal,
+  DialogOverlay,
+  DialogClose,
+  DialogTrigger,
+  DialogContent,
+  DialogHeader,
+  DialogFooter,
+  DialogTitle,
+  DialogDescription,
+};

--- a/src/components/ui/Dialog/index.ts
+++ b/src/components/ui/Dialog/index.ts
@@ -1,0 +1,12 @@
+export {
+  Dialog,
+  DialogPortal,
+  DialogOverlay,
+  DialogClose,
+  DialogTrigger,
+  DialogContent,
+  DialogHeader,
+  DialogFooter,
+  DialogTitle,
+  DialogDescription,
+} from './Dialog';

--- a/src/components/ui/Select/Select.tsx
+++ b/src/components/ui/Select/Select.tsx
@@ -1,0 +1,160 @@
+'use client';
+
+import * as SelectPrimitive from '@radix-ui/react-select';
+import { Check, ChevronDown, ChevronUp } from 'lucide-react';
+import * as React from 'react';
+
+import { cn } from '@/lib/ui-utils';
+
+const Select = SelectPrimitive.Root;
+
+const SelectGroup = SelectPrimitive.Group;
+
+const SelectValue = SelectPrimitive.Value;
+
+const SelectTrigger = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.Trigger>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Trigger>
+>(({ className, children, ...props }, ref) => (
+  <SelectPrimitive.Trigger
+    ref={ref}
+    className={cn(
+      'flex h-11 w-full items-center justify-between rounded-lg border-2 border-black bg-white px-4 py-2 text-sm font-medium text-black focus:ring-2 focus:ring-black focus:ring-offset-2 focus:outline-none disabled:cursor-not-allowed disabled:bg-gray dark:border-white dark:bg-black dark:text-white dark:focus:ring-white dark:disabled:bg-gray',
+      className
+    )}
+    {...props}
+  >
+    {children}
+    <SelectPrimitive.Icon asChild>
+      <ChevronDown className="h-4 w-4 opacity-50" />
+    </SelectPrimitive.Icon>
+  </SelectPrimitive.Trigger>
+));
+SelectTrigger.displayName = SelectPrimitive.Trigger.displayName;
+
+const SelectScrollUpButton = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.ScrollUpButton>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.ScrollUpButton>
+>(({ className, ...props }, ref) => (
+  <SelectPrimitive.ScrollUpButton
+    ref={ref}
+    className={cn(
+      'flex cursor-default items-center justify-center py-1',
+      className
+    )}
+    {...props}
+  >
+    <ChevronUp className="h-4 w-4" />
+  </SelectPrimitive.ScrollUpButton>
+));
+SelectScrollUpButton.displayName = SelectPrimitive.ScrollUpButton.displayName;
+
+const SelectScrollDownButton = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.ScrollDownButton>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.ScrollDownButton>
+>(({ className, ...props }, ref) => (
+  <SelectPrimitive.ScrollDownButton
+    ref={ref}
+    className={cn(
+      'flex cursor-default items-center justify-center py-1',
+      className
+    )}
+    {...props}
+  >
+    <ChevronDown className="h-4 w-4" />
+  </SelectPrimitive.ScrollDownButton>
+));
+SelectScrollDownButton.displayName =
+  SelectPrimitive.ScrollDownButton.displayName;
+
+const SelectContent = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Content>
+>(({ className, children, position = 'popper', ...props }, ref) => (
+  <SelectPrimitive.Portal>
+    <SelectPrimitive.Content
+      ref={ref}
+      className={cn(
+        'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 relative z-50 max-h-96 min-w-[8rem] overflow-hidden rounded-lg border-2 border-black bg-white text-black shadow-md dark:border-white dark:bg-black dark:text-white',
+        position === 'popper' &&
+          'data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1',
+        className
+      )}
+      position={position}
+      {...props}
+    >
+      <SelectScrollUpButton />
+      <SelectPrimitive.Viewport
+        className={cn(
+          'p-1',
+          position === 'popper' &&
+            'h-[var(--radix-select-trigger-height)] w-full min-w-[var(--radix-select-trigger-width)]'
+        )}
+      >
+        {children}
+      </SelectPrimitive.Viewport>
+      <SelectScrollDownButton />
+    </SelectPrimitive.Content>
+  </SelectPrimitive.Portal>
+));
+SelectContent.displayName = SelectPrimitive.Content.displayName;
+
+const SelectLabel = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.Label>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Label>
+>(({ className, ...props }, ref) => (
+  <SelectPrimitive.Label
+    ref={ref}
+    className={cn('py-1.5 pr-2 pl-8 text-sm font-semibold', className)}
+    {...props}
+  />
+));
+SelectLabel.displayName = SelectPrimitive.Label.displayName;
+
+const SelectItem = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.Item>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Item>
+>(({ className, children, ...props }, ref) => (
+  <SelectPrimitive.Item
+    ref={ref}
+    className={cn(
+      'relative flex w-full cursor-default items-center rounded-sm py-1.5 pr-2 pl-8 text-sm outline-none select-none focus:bg-black focus:text-white data-[disabled]:pointer-events-none data-[disabled]:opacity-50 dark:focus:bg-white dark:focus:text-black',
+      className
+    )}
+    {...props}
+  >
+    <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
+      <SelectPrimitive.ItemIndicator>
+        <Check className="h-4 w-4" />
+      </SelectPrimitive.ItemIndicator>
+    </span>
+
+    <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
+  </SelectPrimitive.Item>
+));
+SelectItem.displayName = SelectPrimitive.Item.displayName;
+
+const SelectSeparator = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.Separator>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Separator>
+>(({ className, ...props }, ref) => (
+  <SelectPrimitive.Separator
+    ref={ref}
+    className={cn('-mx-1 my-1 h-px bg-black/10 dark:bg-white/10', className)}
+    {...props}
+  />
+));
+SelectSeparator.displayName = SelectPrimitive.Separator.displayName;
+
+export {
+  Select,
+  SelectGroup,
+  SelectValue,
+  SelectTrigger,
+  SelectContent,
+  SelectLabel,
+  SelectItem,
+  SelectScrollUpButton,
+  SelectScrollDownButton,
+  SelectSeparator,
+};

--- a/src/components/ui/Select/index.ts
+++ b/src/components/ui/Select/index.ts
@@ -1,0 +1,12 @@
+export {
+  Select,
+  SelectGroup,
+  SelectValue,
+  SelectTrigger,
+  SelectContent,
+  SelectLabel,
+  SelectItem,
+  SelectScrollUpButton,
+  SelectScrollDownButton,
+  SelectSeparator,
+} from './Select';

--- a/src/lib/auth/server.ts
+++ b/src/lib/auth/server.ts
@@ -58,6 +58,19 @@ export async function getCurrentUser(): Promise<User | null> {
  * 認証が必要なページで使用。未認証の場合はサインインページにリダイレクト
  */
 export async function requireAuth(redirectTo?: string): Promise<User> {
+  // E2Eテストモード: 認証をスキップし、ダミーユーザーを返す
+  if (process.env.E2E_TEST_MODE === 'true') {
+    return {
+      id: 'test-user-id',
+      email: 'test@example.com',
+      aud: 'authenticated',
+      role: 'authenticated',
+      created_at: new Date().toISOString(),
+      app_metadata: {},
+      user_metadata: {},
+    } as User;
+  }
+
   const user = await getCurrentUser();
 
   if (!user) {


### PR DESCRIPTION
- HabitFormコンポーネントをsrc/components/feature/HabitFormに移動
- E2Eテスト用のe2e/habit-form.spec.tsを作成
  - フォーム表示、バリデーション、習慣作成などの主要フローをカバー
  - レスポンシブ対応のテストを含む
- E2Eテストモード用の認証スキップ機能を実装
  - middleware.tsにE2E_TEST_MODEチェックを追加
  - src/lib/auth/server.tsのrequireAuthにダミーユーザー返却ロジックを追加
  - playwright.config.tsにE2E_TEST_MODE環境変数を設定
- Storybookの型エラーを修正
- importの順序を修正してlintエラーを解消

🤖 Generated with [Claude Code](https://claude.com/claude-code)